### PR TITLE
fix game crashing while trying to open CBrush inspector

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -468,6 +468,13 @@ namespace big
 	{
 		ImGui::Begin("CBrush Details", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
 
+		if (g_selected_cbrush_detail_inspector < 0 || static_cast<size_t>(g_selected_cbrush_detail_inspector) >= g_cbrushes.size())
+		{
+			ImGui::Text("No brush selected.");
+			ImGui::End();
+			return;
+		}
+
 		const auto& brush = g_cbrushes[g_selected_cbrush_detail_inspector];
 
 		ImGui::Text("Name: %s", brush->GetName());


### PR DESCRIPTION
![0xB](https://github.com/user-attachments/assets/d8287885-791e-441f-8158-7c73dbe9f9b9)

![0xA](https://github.com/user-attachments/assets/6490d2b2-af9c-4ba3-ac12-473b2ec7d0a6)

i think now the CBrush inspector is usable no crashes 