### PR TITLE
proper VFTable hooks and fix performance issues with C3DEngine hooks

### DIFF
--- a/src/kcd2_init.hpp
+++ b/src/kcd2_init.hpp
@@ -1467,7 +1467,7 @@ namespace big
 
 	inline uintptr_t g_C3DEngine = 0;
 
-	inline std::vector<IRenderNode *> g_rendernodes;
+	inline ankerl::unordered_dense::set<IRenderNode *> g_rendernodes;
 
 	inline std::vector<IPhysicalEntity *> g_physicalentities;
 


### PR DESCRIPTION
- optimized VFTable hooks no more runtime hooking
- hooks with C3DEngine mainly:  hook_C3DEngine_RegisterEntity hook_C3DEngine_UnRegisterEntityImpl were killing fps so much(it was hard to find this out)
- converted C3DEngine hooks to use unordered_dense to fix the performance issues, for now progressive performance degradation while playing is fixed.
- when I get time I'll convert others e.g -> std::vector<CBrush*> g_cbrushes to use unordered_dense for further performance improvements  ( maybe in another PR :(      )