### PR TITLE
use mimalloc v2 instead of v3

### DIFF
--- a/cmake_scripts/mimalloc.cmake
+++ b/cmake_scripts/mimalloc.cmake
@@ -5,7 +5,7 @@ set(MI_OVERRIDE OFF)
 FetchContent_Declare(
 	mimalloc
 	GIT_REPOSITORY https://github.com/microsoft/mimalloc.git
-    GIT_TAG        v3.0.3
+    GIT_TAG        v2.2.3
     GIT_SHALLOW    TRUE
     GIT_PROGRESS   TRUE
 )


### PR DESCRIPTION
there are several issues with mimalloc v3:
- random(hard to debug) crashes during gameplay without stack trace or anything(on debugging looks like bitmap related shit)
- game won't start if mimalloc is compiled with /Os flag(starts frozen and no crashes) but will work if /Ot or neither of these is used.
- some strange behavioral patterns like: after every restart of windows on 1st start game will freeze if you wait in game, then if you somehow close the game and restart it won't appear again but there are other crashes that are being traced back to mimalloc